### PR TITLE
capturing stderr in twisted.conch.manhole for Python 3 compatibility

### DIFF
--- a/src/twisted/conch/manhole.py
+++ b/src/twisted/conch/manhole.py
@@ -110,11 +110,14 @@ class ManholeInterpreter(code.InteractiveInterpreter):
     def runcode(self, *a, **kw):
         orighook, sys.displayhook = sys.displayhook, self.displayhook
         try:
-            origout, sys.stdout = sys.stdout, FileWrapper(self.handler)
+            origout = sys.stdout
+            origerr = sys.stderr
+            sys.stdout = sys.stderr = FileWrapper(self.handler)
             try:
                 code.InteractiveInterpreter.runcode(self, *a, **kw)
             finally:
                 sys.stdout = origout
+                sys.stderr = origerr
         finally:
             sys.displayhook = orighook
 


### PR DESCRIPTION
Currently ManholeInterpreter captures stdout only, while it has to capture stderr as well to work with Python 3; otherwise exceptions are not printed at all. See Trac 9286.